### PR TITLE
add security label

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,21 @@ This provider allows to manage settings and configurations of existing roles (cr
 
 This aims at using Google's [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres), where [google_sql_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) is used to create roles in PostgreSQL but further configurations for those roles are not supported innately.
 
+## Features
+
+This provider supports managing the following role configurations:
+
+- **Audit settings** - Configure pgAudit logging for roles
+- **Bypass RLS** - Manage row-level security bypass permissions
+- **Connection limits** - Set maximum concurrent connections per role
+- **Replication** - Configure replication permissions
+- **Statement timeout** - Set query execution timeout limits
+- **Security labels** - Manage PostgreSQL Anonymizer security labels for dynamic masking
+
 ## Quick Starts
 
 * [Provider Documentation](https://registry.terraform.io/providers/anhpngt/pgrole/latest/docs)
+* [Dynamic Masking Complete Example](examples/dynamic_masking_complete.md)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This provider supports managing the following role configurations:
 ## Quick Starts
 
 * [Provider Documentation](https://registry.terraform.io/providers/anhpngt/pgrole/latest/docs)
-* [Dynamic Masking Complete Example](examples/dynamic_masking_complete.md)
 
 ## Requirements
 

--- a/docs/resources/security_label.md
+++ b/docs/resources/security_label.md
@@ -1,0 +1,74 @@
+# pgrole_security_label Resource
+
+Manages PostgreSQL Anonymizer security labels for roles to enable dynamic masking. 
+
+This resource allows you to apply security labels to PostgreSQL roles using the PostgreSQL Anonymizer extension. Security labels are used to mark roles as "MASKED" for dynamic masking purposes, where sensitive data is automatically masked when accessed by those roles.
+
+## Example Usage
+
+```terraform
+# Mark a role as masked for dynamic masking
+resource "pgrole_security_label" "app_user" {
+  role  = "app_user"
+  label = "MASKED"
+}
+
+# Remove masking from a role (unmask)
+resource "pgrole_security_label" "admin_user" {
+  role  = "admin_user"
+  label = null
+}
+
+# Custom security label
+resource "pgrole_security_label" "custom" {
+  role  = "special_user"
+  label = "CUSTOM_LABEL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `role` - (Required) Name of the PostgreSQL role to apply the security label to.
+* `label` - (Optional) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label. If not specified, defaults to `"MASKED"`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `role` - The name of the role.
+* `label` - The current security label value for the role.
+
+## Import
+
+Security label resources can be imported using the role name:
+
+```shell
+terraform import pgrole_security_label.example role_name
+```
+
+## Prerequisites
+
+Before using this resource, ensure that:
+
+1. The PostgreSQL Anonymizer extension is installed and enabled in your database
+2. Dynamic masking is enabled: `ALTER DATABASE your_db SET anon.transparent_dynamic_masking TO true;`
+3. The provider has sufficient privileges to manage security labels
+
+## Dynamic Masking Workflow
+
+1. **Enable PostgreSQL Anonymizer**: Install and enable the extension
+2. **Set up masking rules**: Define masking rules for sensitive columns
+3. **Create masked roles**: Use this resource to mark roles as `"MASKED"`
+4. **Grant appropriate permissions**: Ensure masked roles have read access to the data
+
+For more information, see the [PostgreSQL Anonymizer Dynamic Masking documentation](https://postgresql-anonymizer.readthedocs.io/en/latest/dynamic_masking/).
+
+## SQL Operations
+
+This resource performs the following SQL operations:
+
+* **Create/Update**: `SECURITY LABEL FOR anon ON ROLE role_name IS 'label_value';`
+* **Delete/Null**: `SECURITY LABEL FOR anon ON ROLE role_name IS NULL;`
+* **Read**: Queries `pg_seclabels` system catalog for existing labels

--- a/docs/resources/security_label.md
+++ b/docs/resources/security_label.md
@@ -13,12 +13,6 @@ resource "pgrole_security_label" "app_user" {
   label = "MASKED"
 }
 
-# Remove masking from a role (unmask)
-resource "pgrole_security_label" "admin_user" {
-  role  = "admin_user"
-  label = null
-}
-
 # Custom security label
 resource "pgrole_security_label" "custom" {
   role  = "special_user"

--- a/docs/resources/security_label.md
+++ b/docs/resources/security_label.md
@@ -25,7 +25,7 @@ resource "pgrole_security_label" "custom" {
 The following arguments are supported:
 
 * `role` - (Required) Name of the PostgreSQL role to apply the security label to.
-* `label` - (Required) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label.
+* `label` - (Required) Security label value. Use `"MASKED"` to enable dynamic masking for the role. Destroying this resource will remove the associated security label.
 
 ## Attribute Reference
 

--- a/docs/resources/security_label.md
+++ b/docs/resources/security_label.md
@@ -31,7 +31,7 @@ resource "pgrole_security_label" "custom" {
 The following arguments are supported:
 
 * `role` - (Required) Name of the PostgreSQL role to apply the security label to.
-* `label` - (Required) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label`.
+* `label` - (Required) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label.
 
 ## Attribute Reference
 

--- a/docs/resources/security_label.md
+++ b/docs/resources/security_label.md
@@ -31,7 +31,7 @@ resource "pgrole_security_label" "custom" {
 The following arguments are supported:
 
 * `role` - (Required) Name of the PostgreSQL role to apply the security label to.
-* `label` - (Optional) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label. If not specified, defaults to `"MASKED"`.
+* `label` - (Required) Security label value. Use `"MASKED"` to enable dynamic masking for the role, or `null` to remove the label`.
 
 ## Attribute Reference
 

--- a/examples/resources/pgrole_security_label/import.sh
+++ b/examples/resources/pgrole_security_label/import.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Import an existing security label for a role
+terraform import pgrole_security_label.masked_user "app_user"

--- a/examples/resources/pgrole_security_label/import.sh
+++ b/examples/resources/pgrole_security_label/import.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
 # Import an existing security label for a role
 terraform import pgrole_security_label.masked_user "app_user"

--- a/examples/resources/pgrole_security_label/resource.tf
+++ b/examples/resources/pgrole_security_label/resource.tf
@@ -1,13 +1,3 @@
-terraform {
-  required_providers {
-    pgrole = {
-      source  = "registry.terraform.io/manabie-com/pgrole"
-      version = "0.0.0"
-    }
-  }
-}
-
-# Create a role for dynamic masking
 resource "pgrole_security_label" "masked_user" {
   role  = "app_user"
   label = "MASKED"

--- a/examples/resources/pgrole_security_label/resource.tf
+++ b/examples/resources/pgrole_security_label/resource.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    pgrole = {
+      source  = "registry.terraform.io/manabie-com/pgrole"
+      version = "0.0.0"
+    }
+  }
+}
+
+# Create a role for dynamic masking
+resource "pgrole_security_label" "masked_user" {
+  role  = "app_user"
+  label = "MASKED"
+}
+

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -302,6 +302,7 @@ func (p *pgroleProvider) Resources(ctx context.Context) []func() resource.Resour
 		NewConnectionLimitResource,
 		NewReplicationResource,
 		NewAuditResource,
+		NewSecurityLabelResource,
 	}
 }
 

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -258,7 +258,6 @@ func (r *securityLabelResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *securityLabelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.State.SetAttribute(ctx, path.Root("label"), "MASKED")
 	resource.ImportStatePassthroughID(ctx, path.Root("role"), req, resp)
 }
 

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = (*securityLabelResource)(nil)
+	_ resource.ResourceWithConfigure   = (*securityLabelResource)(nil)
+	_ resource.ResourceWithImportState = (*securityLabelResource)(nil)
+)
+
+// NewSecurityLabelResource is a helper function to simplify the provider implementation.
+func NewSecurityLabelResource() resource.Resource {
+	return &securityLabelResource{}
+}
+
+type securityLabelResource struct {
+	getDB F
+}
+
+// Metadata returns the resource type name.
+func (r *securityLabelResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_security_label"
+}
+
+// Schema defines the schema for the resource.
+func (r *securityLabelResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manage PostgreSQL Anonymizer security labels for roles to enable dynamic masking. See [PostgreSQL Anonymizer Dynamic Masking](https://postgresql-anonymizer.readthedocs.io/en/latest/dynamic_masking/) documentation.",
+		Attributes: map[string]schema.Attribute{
+			"role": schema.StringAttribute{
+				Description: "Name of the role to apply the security label to.",
+				Required:    true,
+			},
+			"label": schema.StringAttribute{
+				Description: "Security label value. Use 'MASKED' to enable dynamic masking for the role, or NULL to remove the label.",
+				Optional:    true,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+type securityLabelModel struct {
+	Role  types.String `tfsdk:"role"`
+	Label types.String `tfsdk:"label"`
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *securityLabelResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Add a nil check when handling ProviderData because Terraform
+	// sets that data after it calls the ConfigureProvider RPC.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(F)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected provider.F, got %T", req.ProviderData),
+		)
+	}
+
+	r.getDB = client
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *securityLabelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Retrieve value from plan
+	var plan securityLabelModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create the resource
+	var sqlstr string
+	if plan.Label.IsNull() || plan.Label.ValueString() == "" {
+		// If no label is specified, default to MASKED
+		plan.Label = types.StringValue("MASKED")
+		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
+	} else {
+		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
+	}
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get database connection",
+			"Failed to get database connection: "+err.Error(),
+		)
+		return
+	}
+	defer db.Close()
+
+	if _, err = db.ExecContext(ctx, sqlstr); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to execute SQL",
+			"Failed to execute SQL: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "Created security label for role", map[string]any{
+		"role":  plan.Role.ValueString(),
+		"label": plan.Label.ValueString(),
+	})
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *securityLabelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Get the current state
+	var state securityLabelModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the actual value in postgres
+	db, err := r.getDB(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get database connection",
+			"Failed to get database connection: "+err.Error(),
+		)
+		return
+	}
+	defer db.Close()
+
+	var label sql.NullString
+	sqlstr := `SELECT label 
+FROM pg_seclabels 
+WHERE objtype = 'role' 
+AND provider = 'anon' 
+AND objname = $1`
+
+	err = db.QueryRowContext(ctx, sqlstr, state.Role.ValueString()).Scan(&label)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// No security label found, set to null
+		state.Label = types.StringNull()
+	case err == nil:
+		if label.Valid {
+			state.Label = types.StringValue(label.String)
+		} else {
+			state.Label = types.StringNull()
+		}
+	default:
+		resp.Diagnostics.AddError(
+			"Failed to query security label",
+			fmt.Sprintf("Failed to query security label for role %s: %s", state.Role.ValueString(), err),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "Read security label for role", map[string]any{
+		"role":  state.Role.ValueString(),
+		"label": state.Label.ValueString(),
+	})
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Retrieve value from plan
+	var plan securityLabelModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update resource state with updated values
+	var sqlstr string
+	if plan.Label.IsNull() || strings.ToUpper(plan.Label.ValueString()) == "NULL" {
+		sqlstr = sqlRemoveSecurityLabel(plan.Role.ValueString())
+		plan.Label = types.StringNull()
+	} else {
+		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
+	}
+
+	db, err := r.getDB(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get database connection",
+			"Failed to get database connection: "+err.Error(),
+		)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, sqlstr); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to execute SQL",
+			"Failed to execute SQL: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "Updated security label for role", map[string]any{
+		"role":  plan.Role.ValueString(),
+		"label": plan.Label.ValueString(),
+	})
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *securityLabelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Retrieve value from state
+	var state securityLabelModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Delete the resource by removing the security label
+	sqlstr := sqlRemoveSecurityLabel(state.Role.ValueString())
+	db, err := r.getDB(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get database connection",
+			"Failed to get database connection: "+err.Error(),
+		)
+		return
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, sqlstr); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to execute SQL",
+			"Failed to execute SQL: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "Deleted security label for role", map[string]any{
+		"role": state.Role.ValueString(),
+	})
+}
+
+func (r *securityLabelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import state by role name, the label will be read from the database
+	resource.ImportStatePassthroughID(ctx, path.Root("role"), req, resp)
+}
+
+// sqlSetSecurityLabel generates SQL to set a security label for a role
+func sqlSetSecurityLabel(role string, label string) string {
+	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %s IS '%s';", role, label)
+}
+
+// sqlRemoveSecurityLabel generates SQL to remove a security label for a role
+func sqlRemoveSecurityLabel(role string) string {
+	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %s IS NULL;", role)
+}

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -191,7 +191,7 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 
 	// Update resource state with updated values
 	var sqlstr string
-	if plan.Label == "" || strings.ToUpper(plan.Label) == "NULL" {
+	if plan.Label == "" {
 		sqlstr = sqlRemoveSecurityLabel(plan.Role)
 		plan.Label = ""
 	} else {
@@ -270,7 +270,8 @@ func (r *securityLabelResource) ImportState(ctx context.Context, req resource.Im
 
 // sqlSetSecurityLabel generates SQL to set a security label for a role
 func sqlSetSecurityLabel(role string, label string) string {
-	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %q IS '%s';", role, label)
+	escapedLabel := strings.ReplaceAll(label, "'", "''")
+	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %q IS '%s';", role, escapedLabel)
 }
 
 // sqlRemoveSecurityLabel generates SQL to remove a security label for a role

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -46,16 +45,15 @@ func (r *securityLabelResource) Schema(_ context.Context, req resource.SchemaReq
 			},
 			"label": schema.StringAttribute{
 				Description: "Security label value. Use 'MASKED' to enable dynamic masking for the role, or NULL to remove the label.",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 			},
 		},
 	}
 }
 
 type securityLabelModel struct {
-	Role  types.String `tfsdk:"role"`
-	Label types.String `tfsdk:"label"`
+	Role  string `tfsdk:"role"`
+	Label string `tfsdk:"label"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -88,14 +86,7 @@ func (r *securityLabelResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Create the resource
-	var sqlstr string
-	if plan.Label.IsNull() || plan.Label.ValueString() == "" {
-		// If no label is specified, default to MASKED
-		plan.Label = types.StringValue("MASKED")
-		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
-	} else {
-		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
-	}
+	sqlstr := sqlSetSecurityLabel(plan.Role, plan.Label)
 
 	db, err := r.getDB(ctx)
 	if err != nil {
@@ -116,8 +107,8 @@ func (r *securityLabelResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	tflog.Info(ctx, "Created security label for role", map[string]any{
-		"role":  plan.Role.ValueString(),
-		"label": plan.Label.ValueString(),
+		"role":  plan.Role,
+		"label": plan.Label,
 	})
 
 	// Set state to fully populated data
@@ -156,28 +147,28 @@ WHERE objtype = 'role'
 AND provider = 'anon' 
 AND objname = $1`
 
-	err = db.QueryRowContext(ctx, sqlstr, state.Role.ValueString()).Scan(&label)
+	err = db.QueryRowContext(ctx, sqlstr, state.Role).Scan(&label)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
-		// No security label found, set to null
-		state.Label = types.StringNull()
+		// No security label found, set to empty
+		state.Label = ""
 	case err == nil:
 		if label.Valid {
-			state.Label = types.StringValue(label.String)
+			state.Label = label.String
 		} else {
-			state.Label = types.StringNull()
+			state.Label = ""
 		}
 	default:
 		resp.Diagnostics.AddError(
 			"Failed to query security label",
-			fmt.Sprintf("Failed to query security label for role %s: %s", state.Role.ValueString(), err),
+			fmt.Sprintf("Failed to query security label for role %s: %s", state.Role, err),
 		)
 		return
 	}
 
 	tflog.Info(ctx, "Read security label for role", map[string]any{
-		"role":  state.Role.ValueString(),
-		"label": state.Label.ValueString(),
+		"role":  state.Role,
+		"label": state.Label,
 	})
 
 	// Set refreshed state
@@ -200,11 +191,11 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 
 	// Update resource state with updated values
 	var sqlstr string
-	if plan.Label.IsNull() || strings.ToUpper(plan.Label.ValueString()) == "NULL" {
-		sqlstr = sqlRemoveSecurityLabel(plan.Role.ValueString())
-		plan.Label = types.StringNull()
+	if plan.Label == "" || strings.ToUpper(plan.Label) == "NULL" {
+		sqlstr = sqlRemoveSecurityLabel(plan.Role)
+		plan.Label = ""
 	} else {
-		sqlstr = sqlSetSecurityLabel(plan.Role.ValueString(), plan.Label.ValueString())
+		sqlstr = sqlSetSecurityLabel(plan.Role, plan.Label)
 	}
 
 	db, err := r.getDB(ctx)
@@ -226,8 +217,8 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	tflog.Info(ctx, "Updated security label for role", map[string]any{
-		"role":  plan.Role.ValueString(),
-		"label": plan.Label.ValueString(),
+		"role":  plan.Role,
+		"label": plan.Label,
 	})
 
 	diags = resp.State.Set(ctx, plan)
@@ -248,7 +239,7 @@ func (r *securityLabelResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	// Delete the resource by removing the security label
-	sqlstr := sqlRemoveSecurityLabel(state.Role.ValueString())
+	sqlstr := sqlRemoveSecurityLabel(state.Role)
 	db, err := r.getDB(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -268,7 +259,7 @@ func (r *securityLabelResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	tflog.Info(ctx, "Deleted security label for role", map[string]any{
-		"role": state.Role.ValueString(),
+		"role": state.Role,
 	})
 }
 
@@ -279,10 +270,10 @@ func (r *securityLabelResource) ImportState(ctx context.Context, req resource.Im
 
 // sqlSetSecurityLabel generates SQL to set a security label for a role
 func sqlSetSecurityLabel(role string, label string) string {
-	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %s IS '%s';", role, label)
+	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %q IS '%s';", role, label)
 }
 
 // sqlRemoveSecurityLabel generates SQL to remove a security label for a role
 func sqlRemoveSecurityLabel(role string) string {
-	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %s IS NULL;", role)
+	return fmt.Sprintf("SECURITY LABEL FOR anon ON ROLE %q IS NULL;", role)
 }

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -151,7 +151,8 @@ AND objname = $1`
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// No security label found, set to empty
-		state.Label = ""
+		resp.State.RemoveResource(ctx)
+		return
 	case err == nil:
 		if label.Valid {
 			state.Label = label.String
@@ -191,7 +192,7 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 
 	// Update resource state with updated values
 	var sqlstr string
-	if plan.Label == "" {
+	if plan.Label == "NULL" {
 		sqlstr = sqlRemoveSecurityLabel(plan.Role)
 	} else {
 		sqlstr = sqlSetSecurityLabel(plan.Role, plan.Label)
@@ -263,7 +264,7 @@ func (r *securityLabelResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *securityLabelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import state by role name, the label will be read from the database
+	resp.State.SetAttribute(ctx, path.Root("label"), "MASKED")
 	resource.ImportStatePassthroughID(ctx, path.Root("role"), req, resp)
 }
 

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -193,7 +193,6 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 	var sqlstr string
 	if plan.Label == "" {
 		sqlstr = sqlRemoveSecurityLabel(plan.Role)
-		plan.Label = ""
 	} else {
 		sqlstr = sqlSetSecurityLabel(plan.Role, plan.Label)
 	}

--- a/internal/provider/security_label_resource.go
+++ b/internal/provider/security_label_resource.go
@@ -151,8 +151,7 @@ AND objname = $1`
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// No security label found, set to empty
-		resp.State.RemoveResource(ctx)
-		return
+		state.Label = ""
 	case err == nil:
 		if label.Valid {
 			state.Label = label.String
@@ -191,12 +190,7 @@ func (r *securityLabelResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	// Update resource state with updated values
-	var sqlstr string
-	if plan.Label == "NULL" {
-		sqlstr = sqlRemoveSecurityLabel(plan.Role)
-	} else {
-		sqlstr = sqlSetSecurityLabel(plan.Role, plan.Label)
-	}
+	sqlstr := sqlSetSecurityLabel(plan.Role, plan.Label)
 
 	db, err := r.getDB(ctx)
 	if err != nil {

--- a/internal/provider/security_label_resource_test.go
+++ b/internal/provider/security_label_resource_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSecurityLabelResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfig + `
+resource "pgrole_security_label" "test" {
+  role  = "test_role"
+  label = "MASKED"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role"),
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "label", "MASKED"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "pgrole_security_label.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: providerConfig + `
+resource "pgrole_security_label" "test" {
+  role  = "test_role"
+  label = "CUSTOM_LABEL"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role"),
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "label", "CUSTOM_LABEL"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccSecurityLabelResourceRemoveLabel(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with MASKED label
+			{
+				Config: providerConfig + `
+resource "pgrole_security_label" "test" {
+  role  = "test_role2"
+  label = "MASKED"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role2"),
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "label", "MASKED"),
+				),
+			},
+			// Remove the label (set to null)
+			{
+				Config: providerConfig + `
+resource "pgrole_security_label" "test" {
+  role  = "test_role2"
+  label = null
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role2"),
+					resource.TestCheckNoResourceAttr("pgrole_security_label.test", "label"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/security_label_resource_test.go
+++ b/internal/provider/security_label_resource_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSecurityLabelResource(t *testing.T) {
+func TestSecurityLabelResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/security_label_resource_test.go
+++ b/internal/provider/security_label_resource_test.go
@@ -46,37 +46,3 @@ resource "pgrole_security_label" "test" {
 		},
 	})
 }
-
-func TestAccSecurityLabelResourceRemoveLabel(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create with MASKED label
-			{
-				Config: providerConfig + `
-resource "pgrole_security_label" "test" {
-  role  = "test_role2"
-  label = "MASKED"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role2"),
-					resource.TestCheckResourceAttr("pgrole_security_label.test", "label", "MASKED"),
-				),
-			},
-			// Remove the label (set to null)
-			{
-				Config: providerConfig + `
-resource "pgrole_security_label" "test" {
-  role  = "test_role2"
-  label = null
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("pgrole_security_label.test", "role", "test_role2"),
-					resource.TestCheckNoResourceAttr("pgrole_security_label.test", "label"),
-				),
-			},
-		},
-	})
-}

--- a/tests/resources/pgrole_security_label/provider.tf
+++ b/tests/resources/pgrole_security_label/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    pgrole = {
+      source = "registry.terraform.io/manabie-com/pgrole"
+    }
+  }
+}

--- a/tests/resources/pgrole_security_label/provider.tf
+++ b/tests/resources/pgrole_security_label/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     pgrole = {
-      source = "registry.terraform.io/manabie-com/pgrole"
+      source  = "local/pgrole"
+      version = "1.0.0"
     }
   }
 }

--- a/tests/resources/pgrole_security_label/resource.tf
+++ b/tests/resources/pgrole_security_label/resource.tf
@@ -1,0 +1,4 @@
+resource "pgrole_security_label" "test" {
+  role  = "test_user"
+  label = "MASKED"
+}


### PR DESCRIPTION
- **Security labels** - Manage PostgreSQL Anonymizer security labels for dynamic masking
- Marking role document https://postgresql-anonymizer.readthedocs.io/en/stable/runbooks/2-dynamic_masking/#masking-a-role